### PR TITLE
feat(reports): automatic anonymization of personal data in CSV export and here tests

### DIFF
--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,54 @@
+from django.test import TestCase
+from users.services import (
+    get_content_analytics, format_analytics_for_csv, _strip_pii, PII_COLUMNS
+)
+
+
+class PIIAnonymizationTest(TestCase):
+
+    def test_get_content_analytics_returns_no_pii_fields(self):
+        data = get_content_analytics()
+        for row in data:
+            for col in row:
+                self.assertNotIn(col, PII_COLUMNS,
+                                 f"PII column '{col}' found in analytics data")
+
+    def test_format_analytics_never_contains_pii(self):
+        rows = [
+            {
+                'title': 'Test',
+                'username': 'john_doe',
+                'email': 'john@example.com',
+                'ip_address': '192.168.1.1',
+            }
+        ]
+        result = format_analytics_for_csv(rows, is_b2b_report=False)
+        for row in result:
+            self.assertNotIn('username', row)
+            self.assertNotIn('email', row)
+            self.assertNotIn('ip_address', row)
+            self.assertIn('title', row)
+
+    def test_b2b_mode_hashes_username(self):
+        rows = [
+            {'title': 'Test', 'username': 'john_doe', 'email': 'john@example.com'}
+        ]
+        result = format_analytics_for_csv(rows, is_b2b_report=True)
+        row = result[0]
+        self.assertTrue(row['username'].startswith('USER_'))
+        self.assertEqual(len(row['username']), 15)
+        self.assertNotIn('email', row)
+
+    def test_strip_pii_removes_all_sensitive_fields(self):
+        row = {'title': 'Movie', 'username': 'user', 'email': 'a@b.com', 'location': 'NYC'}
+        clean = _strip_pii(row)
+        self.assertIn('title', clean)
+        self.assertNotIn('username', clean)
+        self.assertNotIn('email', clean)
+        self.assertNotIn('location', clean)
+
+    def test_pii_columns_contains_expected_fields(self):
+        self.assertIn('username', PII_COLUMNS)
+        self.assertIn('email', PII_COLUMNS)
+        has_ip = 'ip_address' in PII_COLUMNS or 'id_address' in PII_COLUMNS
+        self.assertTrue(has_ip)

--- a/users/services.py
+++ b/users/services.py
@@ -3,6 +3,15 @@ from django.db.models import Count, Q
 from web_app.models import Contingut, Visualitzacio, Preferits, API, Genre, AgeRating, Director
 from django.utils import timezone
 
+PII_COLUMNS = frozenset({
+    'username', 'email', 'ip_address', 'id_address',
+    'first_name', 'last_name', 'location', 'bio',
+    'avatar', 'password',
+})
+
+def _strip_pii(row):
+    return {k: v for k, v in row.items() if k not in PII_COLUMNS}
+
 def get_content_analytics(start_date=None, end_date=None, plataform_id=None):
     queryset = Contingut.objects.select_related('genere', 'age_rating', 'api', 'director')
 
@@ -45,15 +54,14 @@ def get_content_analytics(start_date=None, end_date=None, plataform_id=None):
 def format_analytics_for_csv (data_list, is_b2b_report = False):
     formatted_data = []
     for row in data_list:
+        safe_row = _strip_pii(row)
+
         if is_b2b_report:
             if 'username' in row and row['username']:
                 user_hash = hashlib.sha256(row['username'].encode()).hexdigest()[:10]
-                row['username'] = f"USER_{user_hash}"
-            
-            row.pop('email', None)
-            row.pop('id_address', None)
+                safe_row['username'] = f"USER_{user_hash}"
         
-        formatted_data.append(row)
+        formatted_data.append(safe_row)
         
     return formatted_data
 

--- a/users/views.py
+++ b/users/views.py
@@ -8,7 +8,8 @@ from .services import (
     format_analytics_for_csv,
     get_genre_distribution,
     get_age_rating_distribution,
-    get_director_top_list
+    get_director_top_list,
+    PII_COLUMNS,
 )
 from django.shortcuts import render, redirect
 from django.contrib import messages
@@ -105,6 +106,11 @@ def export_analytics_csv(request):
             item['year'], item['director'], item['platform'], 
             item['views'], item['favorites']
         ])
+    
+    for item in clean_data:
+        leaked = PII_COLUMNS & item.keys()
+        if leaked:
+            raise ValueError(f"CRITICAL: PII columns {leaked} would be exported!")
     
     return response
 


### PR DESCRIPTION
## 📝 Description
**Resol #(issue)** — Automatic anonymization of personal data in report exports.
The CSV export system previously relied on accidental omission of PII fields rather than explicit protection. This PR adds a robust, test-covered anonymization layer that guarantees personal data never appears in exports.
## ✅ Changes
### `users/services.py`
- Added `PII_COLUMNS` frozenset with all sensitive fields (`username`, `email`, `ip_address`, `id_address`, `first_name`, `last_name`, `location`, `bio`, `avatar`, `password`)
- Added `_strip_pii()` helper that removes any PII field from a data row
- Refactored `format_analytics_for_csv()` to **always** sanitize data, regardless of report type (internal or B2B)
### `users/views.py`
- Added safety assertion in `export_analytics_csv()` that raises `ValueError` if any PII column would leak into the CSV response
### `tests/test_reports.py` (new)
- 5 tests covering:
  - Analytics query returns no PII fields
  - `format_analytics_for_csv()` strips PII even when injected
  - B2B mode hashes username but strips other PII
  - `_strip_pii()` removes all sensitive fields
  - `PII_COLUMNS` contains expected fields
## 🧪 Testing
```bash
python manage.py test tests.test_reports
```
All 5 new tests pass. Existing test suite unaffected.