### PR TITLE
120 featreports autonomous generation of segmented and anonymized market reports

### DIFF
--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,54 @@
+from django.test import TestCase
+from users.services import (
+    get_content_analytics, format_analytics_for_csv, _strip_pii, PII_COLUMNS
+)
+
+
+class PIIAnonymizationTest(TestCase):
+
+    def test_get_content_analytics_returns_no_pii_fields(self):
+        data = get_content_analytics()
+        for row in data:
+            for col in row:
+                self.assertNotIn(col, PII_COLUMNS,
+                                 f"PII column '{col}' found in analytics data")
+
+    def test_format_analytics_never_contains_pii(self):
+        rows = [
+            {
+                'title': 'Test',
+                'username': 'john_doe',
+                'email': 'john@example.com',
+                'ip_address': '192.168.1.1',
+            }
+        ]
+        result = format_analytics_for_csv(rows, is_b2b_report=False)
+        for row in result:
+            self.assertNotIn('username', row)
+            self.assertNotIn('email', row)
+            self.assertNotIn('ip_address', row)
+            self.assertIn('title', row)
+
+    def test_b2b_mode_hashes_username(self):
+        rows = [
+            {'title': 'Test', 'username': 'john_doe', 'email': 'john@example.com'}
+        ]
+        result = format_analytics_for_csv(rows, is_b2b_report=True)
+        row = result[0]
+        self.assertTrue(row['username'].startswith('USER_'))
+        self.assertEqual(len(row['username']), 15)
+        self.assertNotIn('email', row)
+
+    def test_strip_pii_removes_all_sensitive_fields(self):
+        row = {'title': 'Movie', 'username': 'user', 'email': 'a@b.com', 'location': 'NYC'}
+        clean = _strip_pii(row)
+        self.assertIn('title', clean)
+        self.assertNotIn('username', clean)
+        self.assertNotIn('email', clean)
+        self.assertNotIn('location', clean)
+
+    def test_pii_columns_contains_expected_fields(self):
+        self.assertIn('username', PII_COLUMNS)
+        self.assertIn('email', PII_COLUMNS)
+        has_ip = 'ip_address' in PII_COLUMNS or 'id_address' in PII_COLUMNS
+        self.assertTrue(has_ip)

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from users.services import (
-    get_content_analytics, format_analytics_for_csv, _strip_pii, PII_COLUMNS
+    get_content_analytics, format_analytics_for_csv, _strip_pii, PII_COLUMNS,
+    GDPR_ANONYMIZE_FIELDS, anonymize_user_id, validate_gdpr_compliance,
 )
 
 
@@ -29,15 +30,18 @@ class PIIAnonymizationTest(TestCase):
             self.assertNotIn('ip_address', row)
             self.assertIn('title', row)
 
-    def test_b2b_mode_hashes_username(self):
+    def test_b2b_mode_anonymizes_gdpr_fields(self):
         rows = [
-            {'title': 'Test', 'username': 'john_doe', 'email': 'john@example.com'}
+            {'title': 'Test', 'username': 'john_doe', 'email': 'john@example.com',
+             'first_name': 'John', 'last_name': 'Doe'}
         ]
         result = format_analytics_for_csv(rows, is_b2b_report=True)
         row = result[0]
-        self.assertTrue(row['username'].startswith('USER_'))
-        self.assertEqual(len(row['username']), 15)
-        self.assertNotIn('email', row)
+        self.assertTrue(row['username'].startswith('UID_'))
+        self.assertEqual(len(row['username']), 16)
+        self.assertTrue(row['email'].startswith('UID_'))
+        self.assertTrue(row['first_name'].startswith('UID_'))
+        self.assertTrue(row['last_name'].startswith('UID_'))
 
     def test_strip_pii_removes_all_sensitive_fields(self):
         row = {'title': 'Movie', 'username': 'user', 'email': 'a@b.com', 'location': 'NYC'}
@@ -52,3 +56,52 @@ class PIIAnonymizationTest(TestCase):
         self.assertIn('email', PII_COLUMNS)
         has_ip = 'ip_address' in PII_COLUMNS or 'id_address' in PII_COLUMNS
         self.assertTrue(has_ip)
+
+
+class GDPRComplianceTest(TestCase):
+
+    def test_anonymize_user_id_is_deterministic(self):
+        uid1 = anonymize_user_id('john_doe')
+        uid2 = anonymize_user_id('john_doe')
+        self.assertEqual(uid1, uid2)
+
+    def test_anonymize_user_id_produces_different_ids_for_different_inputs(self):
+        uid1 = anonymize_user_id('john_doe')
+        uid2 = anonymize_user_id('jane_doe')
+        self.assertNotEqual(uid1, uid2)
+
+    def test_anonymize_user_id_prefix(self):
+        uid = anonymize_user_id('test_user')
+        self.assertTrue(uid.startswith('UID_'))
+
+    def test_validate_gdpr_compliance_passes_for_clean_data(self):
+        data = [{'title': 'Movie', 'views': 10}]
+        validate_gdpr_compliance(data)
+
+    def test_validate_gdpr_compliance_raises_on_pii_columns(self):
+        data = [{'title': 'Movie', 'username': 'john_doe'}]
+        with self.assertRaises(ValueError) as ctx:
+            validate_gdpr_compliance(data)
+        self.assertIn('GDPR violation', str(ctx.exception))
+
+    def test_validate_gdpr_compliance_raises_on_email_in_values(self):
+        data = [{'title': 'Movie', 'note': 'contact john@example.com for info'}]
+        with self.assertRaises(ValueError) as ctx:
+            validate_gdpr_compliance(data)
+        self.assertIn('GDPR violation', str(ctx.exception))
+
+    def test_validate_gdpr_compliance_b2b_raises_on_non_anonymized(self):
+        data = [{'username': 'john_doe'}]
+        with self.assertRaises(ValueError) as ctx:
+            validate_gdpr_compliance(data, is_b2b_report=True)
+        self.assertIn('GDPR violation', str(ctx.exception))
+
+    def test_validate_gdpr_compliance_b2b_passes_with_uid_prefix(self):
+        data = [{'username': 'UID_abc123def456'}]
+        validate_gdpr_compliance(data, is_b2b_report=True)
+
+    def test_gdpr_anonymize_fields_contains_expected(self):
+        self.assertIn('username', GDPR_ANONYMIZE_FIELDS)
+        self.assertIn('email', GDPR_ANONYMIZE_FIELDS)
+        self.assertIn('first_name', GDPR_ANONYMIZE_FIELDS)
+        self.assertIn('last_name', GDPR_ANONYMIZE_FIELDS)

--- a/users/services.py
+++ b/users/services.py
@@ -1,7 +1,10 @@
 import hashlib
+import hmac
+import re
 from django.db.models import Count, Q
 from web_app.models import Contingut, Visualitzacio, Preferits, API, Genre, AgeRating, Director
 from django.utils import timezone
+from django.conf import settings
 
 PII_COLUMNS = frozenset({
     'username', 'email', 'ip_address', 'id_address',
@@ -9,8 +12,36 @@ PII_COLUMNS = frozenset({
     'avatar', 'password',
 })
 
+GDPR_ANONYMIZE_FIELDS = frozenset({
+    'username', 'email', 'first_name', 'last_name',
+    'user_id', 'ip_address', 'id_address',
+})
+
+EMAIL_RE = re.compile(r'[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}')
+
+def anonymize_user_id(identifier, salt=None):
+    salt = salt or settings.SECRET_KEY
+    h = hmac.new(salt.encode(), str(identifier).encode(), hashlib.sha256)
+    return f"UID_{h.hexdigest()[:12]}"
+
 def _strip_pii(row):
     return {k: v for k, v in row.items() if k not in PII_COLUMNS}
+
+def validate_gdpr_compliance(data_list, is_b2b_report=False):
+    for row in data_list:
+        for key, value in row.items():
+            if key in PII_COLUMNS:
+                if is_b2b_report and key in GDPR_ANONYMIZE_FIELDS and isinstance(value, str) and value.startswith('UID_'):
+                    continue
+                raise ValueError(f"GDPR violation: PII column '{key}' found in report data")
+            if isinstance(value, str) and EMAIL_RE.search(value):
+                raise ValueError(f"GDPR violation: email pattern found in field '{key}': {value}")
+        if is_b2b_report:
+            for field in GDPR_ANONYMIZE_FIELDS & row.keys():
+                if not isinstance(row[field], str) or not row[field].startswith('UID_'):
+                    raise ValueError(
+                        f"GDPR violation: field '{field}' in B2B report is not anonymized: {row[field]}"
+                    )
 
 def get_content_analytics(start_date=None, end_date=None, plataform_id=None):
     queryset = Contingut.objects.select_related('genere', 'age_rating', 'api', 'director')
@@ -57,9 +88,8 @@ def format_analytics_for_csv (data_list, is_b2b_report = False):
         safe_row = _strip_pii(row)
 
         if is_b2b_report:
-            if 'username' in row and row['username']:
-                user_hash = hashlib.sha256(row['username'].encode()).hexdigest()[:10]
-                safe_row['username'] = f"USER_{user_hash}"
+            for field in GDPR_ANONYMIZE_FIELDS & row.keys():
+                safe_row[field] = anonymize_user_id(row[field])
         
         formatted_data.append(safe_row)
         

--- a/users/services.py
+++ b/users/services.py
@@ -3,6 +3,15 @@ from django.db.models import Count, Q
 from web_app.models import Contingut, Visualitzacio, Preferits, API, Genre, AgeRating, Director
 from django.utils import timezone
 
+PII_COLUMNS = frozenset({
+    'username', 'email', 'ip_address', 'id_address',
+    'first_name', 'last_name', 'location', 'bio',
+    'avatar', 'password',
+})
+
+def _strip_pii(row):
+    return {k: v for k, v in row.items() if k not in PII_COLUMNS}
+
 def get_content_analytics(start_date=None, end_date=None, plataform_id=None):
     queryset = Contingut.objects.select_related('genere', 'age_rating', 'api', 'director')
 
@@ -45,15 +54,14 @@ def get_content_analytics(start_date=None, end_date=None, plataform_id=None):
 def format_analytics_for_csv (data_list, is_b2b_report = False):
     formatted_data = []
     for row in data_list:
+        safe_row = _strip_pii(row)
+
         if is_b2b_report:
             if 'username' in row and row['username']:
                 user_hash = hashlib.sha256(row['username'].encode()).hexdigest()[:10]
-                row['username'] = f"USER_{user_hash}"
-            
-            row.pop('email', None)
-            row.pop('id_address', None)
+                safe_row['username'] = f"USER_{user_hash}"
         
-        formatted_data.append(row)
+        formatted_data.append(safe_row)
         
     return formatted_data
 

--- a/users/views.py
+++ b/users/views.py
@@ -8,7 +8,8 @@ from .services import (
     format_analytics_for_csv,
     get_genre_distribution,
     get_age_rating_distribution,
-    get_director_top_list
+    get_director_top_list,
+    PII_COLUMNS,
 )
 from django.shortcuts import render, redirect
 from django.contrib import messages
@@ -105,6 +106,11 @@ def export_analytics_csv(request):
             item['year'], item['director'], item['platform'], 
             item['views'], item['favorites']
         ])
+    
+    for item in clean_data:
+        leaked = PII_COLUMNS & item.keys()
+        if leaked:
+            raise ValueError(f"CRITICAL: PII columns {leaked} would be exported!")
     
     return response
 

--- a/users/views.py
+++ b/users/views.py
@@ -10,6 +10,7 @@ from .services import (
     get_age_rating_distribution,
     get_director_top_list,
     PII_COLUMNS,
+    validate_gdpr_compliance,
 )
 from django.shortcuts import render, redirect
 from django.contrib import messages
@@ -111,6 +112,8 @@ def export_analytics_csv(request):
         leaked = PII_COLUMNS & item.keys()
         if leaked:
             raise ValueError(f"CRITICAL: PII columns {leaked} would be exported!")
+    
+    validate_gdpr_compliance(clean_data, is_b2b_report=is_b2b)
     
     return response
 


### PR DESCRIPTION
## 📝 Description
This PR implements two related issues for data protection in analytics report exports:
**feat(reports): automatic anonymization of personal data**
**feat(legal): GDPR compliant anonymization for external platforms**
The system now guarantees that personally identifiable information (PII) is never exported in CSV reports. For internal reports, PII is stripped entirely. For external (B2B) reports, user identifiers are replaced with opaque IDs (`UID_xxx`) using HMAC-SHA256, making them irreversible while remaining deterministic for cross-reference purposes.
## ✅ Changes
### `users/services.py`
- **`PII_COLUMNS`** — frozenset with all sensitive fields: `username`, `email`, `ip_address`, `id_address`, `first_name`, `last_name`, `location`, `bio`, `avatar`, `password`
- **`_strip_pii(row)`** — helper that removes any PII field from a data row. Used in all export modes.
- **`GDPR_ANONYMIZE_FIELDS`** — subset of fields that are anonymized (not stripped) in B2B mode: `username`, `email`, `first_name`, `last_name`, `user_id`, `ip_address`, `id_address`
- **`anonymize_user_id(identifier, salt=None)`** — generates deterministic opaque IDs (`UID_xxxx`) using HMAC-SHA256 with Django's `SECRET_KEY` as default salt. This prevents brute-force recovery of original identifiers.
- **`format_analytics_for_csv()`** — refactored to always sanitize data via `_strip_pii()`. In B2B mode, GDPR fields are kept but replaced with anonymized `UID_` values.
- **`validate_gdpr_compliance()`** — validates the final output:
  - Detects any PII columns in the data
  - Scans field values for email patterns via regex
  - In B2B mode, verifies all GDPR fields use the `UID_` prefix
### `users/views.py`
- Imports `PII_COLUMNS` and `validate_gdpr_compliance`
- Adds safety assertion loop that raises `ValueError` if any PII column leaks
- Calls `validate_gdpr_compliance()` before returning the CSV response
### `tests/test_reports.py` (new file)
14 tests total covering:
| Test | Description |
|------|-------------|
| `test_get_content_analytics_returns_no_pii_fields` | Analytics query never returns PII columns |
| `test_format_analytics_never_contains_pii` | `format_analytics_for_csv()` strips PII even when injected |
| `test_b2b_mode_anonymizes_gdpr_fields` | B2B mode replaces PII with `UID_` values |
| `test_strip_pii_removes_all_sensitive_fields` | `_strip_pii()` removes all sensitive fields |
| `test_pii_columns_contains_expected_fields` | `PII_COLUMNS` has expected entries |
| `test_anonymize_user_id_is_deterministic` | Same input → same `UID_` output |
| `test_anonymize_user_id_produces_different_ids` | Different inputs → different `UID_` outputs |
| `test_anonymize_user_id_prefix` | Output starts with `UID_` |
| `test_validate_gdpr_compliance_passes_for_clean_data` | Clean data passes validation |
| `test_validate_gdpr_compliance_raises_on_pii_columns` | PII columns trigger `ValueError` |
| `test_validate_gdpr_compliance_raises_on_email_in_values` | Email patterns in values trigger `ValueError` |
| `test_validate_gdpr_compliance_b2b_raises_on_non_anonymized` | Non-anonymized B2B data triggers `ValueError` |
| `test_validate_gdpr_compliance_b2b_passes_with_uid_prefix` | Anonymized B2B data passes validation |
| `test_gdpr_anonymize_fields_contains_expected` | `GDPR_ANONYMIZE_FIELDS` has expected entries |
## 🧪 Testing
```bash
python manage.py test tests.test_reports
```
All 14 tests pass. Existing test suite unaffected.
## 🛡️ Security
| Report type |	username	| email	| first_name |
|----|----|----|----|
| Internal|	❌ Stripped	|❌ Stripped|	❌ Stripped |
| B2B|	🔐 UID_xxx |	🔐 UID_xxx |	🔐 UID_xxx |\

## 📁 Files changed

| File	| Status |
|----|----|
| users/services.py |	Modified |
| users/views.py |	Modified |
| tests/test_reports.py |	New |