### PR TITLE
fix(footer): added mailto to the footer email

### DIFF
--- a/Templates/base.html
+++ b/Templates/base.html
@@ -174,7 +174,11 @@
                 </div>
                 <div class="col-md-3 mb-4">
                     <h5>{% trans "Contact" %}</h5>
-                    <p>info@StreamSync.com</p>
+                    <p> 
+                        <a href="mailto:info@StreamSync.com">
+                            info@StreamSync.com
+                        </a>
+                    </p>
                     <p>+34 600 000 000</p>
                 </div>
             </div>


### PR DESCRIPTION
Now, when clicking the mail address, it redirects to a mailto