### PR TITLE
feat(recommendations): fix duplicates and implement carousel in series details

### DIFF
--- a/Templates/Details/details_serie.html
+++ b/Templates/Details/details_serie.html
@@ -18,3 +18,26 @@
 {% endblock %}
 
 {% block favorite_url %}{% url 'toggle_series_favorite' content.id %}{% endblock %}
+
+{% block extra_main_content %}
+<div class="recommendations-section" style="margin: 30px 0;">
+    <h3 class="section-title">{% trans "También te puede gustar..." %}</h3>
+    <div class="recommendations-grid" style="display: flex; gap: 15px; overflow-x: auto; padding-bottom: 10px;">
+        {% for rec in recommendations %}
+            <a href="{% url 'series_detail' rec.id %}" style="text-decoration: none; color: white; min-width: 140px;">
+                {% if rec.poster_path %}
+                    <img src="{{ rec.poster_path }}" alt="{{ rec.title }}" style="width: 140px; height: 210px; object-fit: cover; border-radius: 8px;">
+                {% else %}
+                    <div style="width: 140px; height: 210px; background: rgba(255,255,255,0.05); border-radius: 8px; display: flex; align-items: center; justify-content: center; text-align: center; padding: 10px;">
+                        {{ rec.title }}
+                    </div>
+                {% endif %}
+                <p style="font-size: 0.9rem; margin-top: 8px; font-weight: bold; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">{{ rec.title }}</p>
+            </a>
+        {% empty %}
+            <!-- Mensaje de Fallback -->
+            <p style="color: rgba(255,255,255,0.5);">{% trans "No hay recomendaciones disponibles." %}</p>
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}

--- a/web_app/models.py
+++ b/web_app/models.py
@@ -130,7 +130,7 @@ class Movie(models.Model):
 
         return Movie.objects.filter(
             contingut__genere=self.contingut.genere
-        ).exclude(id=self.id).order_by('?')[:limit]
+        ).exclude(id=self.id).distinct().order_by('?')[:limit]
 
 class Series(models.Model):
     contingut = models.OneToOneField(Contingut, on_delete=models.CASCADE, related_name='series')
@@ -186,6 +186,14 @@ class Series(models.Model):
     @property
     def poster_path(self):
         return self.contingut.poster_path
+
+    def get_similar_by_genre(self, limit=4):
+        if not self.contingut.genere:
+            return Series.objects.none()
+
+        return Series.objects.filter(
+            contingut__genere=self.contingut.genere
+        ).exclude(id=self.id).distinct().order_by('?')[:limit]
 
 
 class CustomUser(AbstractUser):

--- a/web_app/views.py
+++ b/web_app/views.py
@@ -161,6 +161,7 @@ def series_detail(request, pk):
         'reviews': reviews,
         'avg_rating': review_stats['avg_rating'],
         'total_reviews': review_stats['total_reviews'],
+        'recommendations': series.get_similar_by_genre(limit=4)
     })
 
 


### PR DESCRIPTION
## 📄 Description
**As a** platform user (Consumer),
**I want to** see content suggestions ("You might also like...") for both movies and series without encountering duplicated items,
**so that** I can discover relevant content and enjoy a high-quality browsing experience without visual bugs.

**Problem solved:** The recommendations on movie details showed duplicate entries due to database joins, and the series detail view completely lacked the "You might also like..." carousel.

## ✅ Changes Made
- [x] **Backend (Duplicates):** Added `.distinct()` to the `get_similar_by_genre` method in both `Movie` and `Series` models to eliminate duplicate recommendations.
- [x] **Backend (Series):** Implemented the `get_similar_by_genre` method in the `Series` model and injected the `recommendations` variable into the `series_detail` view context.
- [x] **Frontend (Series UI):** Added the recommendation carousel (`{% block extra_main_content %}`) into `details_serie.html`, ensuring the links point correctly to the `series_detail` route.
- [x] **Edge Cases:** Kept the fallback state ("No hay recomendaciones disponibles.") for content lacking similar genres.

## 🛠️ Relevant Files Modified
- `web_app/models.py` (Added `.distinct()` and Series recommendations logic)
- `web_app/views.py` (Injected context for Series details)
- `Templates/Details/details_serie.html` (Added the UI block)

## 🔗 Related Issues
**Closes:** #187

## 📸 Testing Performed
- Checked a Movie detail page to confirm duplicate posters no longer appear.
- Opened a Series detail page and verified the horizontal carousel loads and respects the design.
- Clicked on a recommended series to ensure it redirects correctly to another series page (preventing 404s).
- Verified the empty fallback message works when a series has zero related items.